### PR TITLE
[#12] Fix Router basename

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import NavBar from "./components/NavBar"
 const App = () => {
   return (
     <div className="container mx-auto w-fit-content grid grid-cols-12 gap-20">
-      <BrowserRouter>
+      <BrowserRouter basename={`${import.meta.env.BASE_URL}`}>
       <NavBar />
         <Routes>
           <Route index path="/" element={<Home />} />


### PR DESCRIPTION
The site should now use /portfolio-v2 as the basename. Closes #12 